### PR TITLE
Correct "Continue after failure" for Bazel

### DIFF
--- a/docs/_data/features.yml
+++ b/docs/_data/features.yml
@@ -290,7 +290,7 @@
   scons: '[:white_check_mark:](http://scons.org/doc/production/HTML/scons-man.html)'
 - command_line_interface_continue_execution_after_failures:
   title: 'Continue Execution After Failures'
-  bazel: '[:x:](https://docs.bazel.build/versions/master/command-line-reference.html)'
+  bazel: '[:white_check_mark:](https://docs.bazel.build/versions/master/command-line-reference.html)'
   buck: '[:x:](https://buckbuild.com/command/test.html)'
   conan: '[:x:](http://conanio.readthedocs.io/en/latest/)'
   gradle: '[:white_check_mark:](https://docs.gradle.org/current/userguide/tutorial_gradle_command_line.html#sec:continue_build_on_failure)'


### PR DESCRIPTION
Bazel supports this... see "-k" in https://docs.bazel.build/versions/master/command-line-reference.html